### PR TITLE
Small fix - invalid yaml frontmatter on token-flow-tracing

### DIFF
--- a/agents/skills/evm/token-flow-tracing/SKILL.md
+++ b/agents/skills/evm/token-flow-tracing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "token-flow-tracing"
-description: "Trigger Pattern transfer\|transferFrom\|safeTransfer\|mint\|burn\|balanceOf.this - Inject Into Lifecycle, External-Env agents"
+description: "Performs comprehensive token flow analysis by tracing all token entry and exit paths, verifying accounting consistency, detecting unsolicited transfer vectors, and identifying risks such as donation attacks, balance desynchronization, token type confusion, and side-effect-driven state changes."
 ---
 
 # TOKEN_FLOW_TRACING Skill


### PR DESCRIPTION
`token-flow-tracing` remained invalid after last PR since it contained non-allowed chars in the description - changed to real description (also better for contextual relation of skill invokation)

❤️