### PR TITLE
feat: plamen monitor <interval> — status-heartbeat command for running audits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ scripts/*
 !scripts/plamen_markdown.py
 !scripts/report_index_machinery.py
 !scripts/spike_mechanical_poc.py
+!scripts/plamen_monitor.sh
 sessions/
 settings.json
 shell-snapshots/

--- a/commands/plamen.md
+++ b/commands/plamen.md
@@ -1,5 +1,5 @@
 ﻿---
-description: "Launch the V2 deterministic Smart Contract audit pipeline (same as /plamen-wizard). Usage: /plamen [light|core|thorough] [path]"
+description: "Launch the V2 deterministic Smart Contract audit pipeline (same as /plamen-wizard). Usage: /plamen [light|core|thorough] [path] | /plamen monitor <minutes> [path]"
 ---
 
 # Plamen Audit Pipeline
@@ -11,6 +11,12 @@ description: "Launch the V2 deterministic Smart Contract audit pipeline (same as
 > works identically and is what most users type.
 
 **Routing rule** (evaluate `$ARGUMENTS` exactly once, before any other step):
+
+- If `$ARGUMENTS` contains the literal token `monitor`:
+  - **STOP processing this file.** Execute **Monitor Mode** (the "Monitor Mode"
+    section immediately after this routing block) and do nothing else. Do NOT
+    route to the wizard and do NOT launch the driver — this mode only watches an
+    audit that is **already running**; it never starts one.
 
 - If `$ARGUMENTS` is empty OR does NOT contain the literal token `wrapper-launch`:
   - **STOP processing this file.** Read and execute `~/.claude/commands/plamen-wizard.md`
@@ -40,6 +46,51 @@ description: "Launch the V2 deterministic Smart Contract audit pipeline (same as
 > with a deterministic Python driver. The interactive surface now points at
 > the V2 wizard so users get the reliable path by default, while the driver
 > still uses this file's per-phase sections as subprocess prompts.
+
+---
+
+## Monitor Mode
+
+> **Reached only when `$ARGUMENTS` contains `monitor`** (interactive use). This
+> mode arms a periodic status heartbeat over an audit that is already running in
+> another session — it does not start, resume, or modify any audit.
+>
+> **CLAUDE BACKEND ONLY.** This relies on the Claude Code `Monitor` tool, which
+> streams a script's stdout lines into the chat as notifications. The Codex
+> backend (`codex exec`) has no equivalent — under Codex, tell the user that
+> `monitor` is Claude-only and that they can instead
+> `tail -f <scratchpad>/_plamen.log`, then stop.
+
+Usage: `/plamen monitor <minutes> [path]`
+
+Steps:
+
+1. **Parse the interval.** Take the first integer token after `monitor` as
+   `<minutes>` (the heartbeat cadence). If none is given, default to `15`.
+
+2. **Locate the scratchpad** (`S`):
+   - If `$ARGUMENTS` contains a path token, use `<path>/.scratchpad` (or the
+     token itself if it already ends in `.scratchpad`).
+   - Otherwise search the current directory: prefer `./.scratchpad`, then a
+     single-level `./*/.scratchpad` (e.g. `core/.scratchpad`). The correct
+     scratchpad is the one containing `_v2_checkpoint.json`.
+   - If no scratchpad with `_v2_checkpoint.json` is found, tell the user no
+     running audit was detected and stop.
+
+3. **Arm the watch.** Call the `Monitor` tool with `persistent: true` and:
+
+   ```
+   bash ~/.claude/scripts/plamen_monitor.sh <S> <minutes>
+   ```
+
+   Use a specific `description` such as `plamen audit status (every <minutes>m)`.
+   The script emits a report immediately on arm and then every `<minutes>`,
+   plus event-driven `PROGRESS` / `ALERT-STALL` lines, and a terminal `DONE`
+   (report present) or `ALERT-DEAD` (driver gone, no report) when the run ends.
+
+4. Confirm to the user that the monitor is armed and that they can stop it any
+   time with `TaskStop` (or by ending the session). Then stop — do not proceed
+   to any audit step.
 
 ---
 

--- a/scripts/plamen_monitor.sh
+++ b/scripts/plamen_monitor.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# plamen monitor — periodic status heartbeat for a running plamen V2 audit.
+#
+# Usage:   plamen_monitor.sh <scratchpad_dir> [interval_minutes]
+# Example: plamen_monitor.sh /path/to/project/.scratchpad 15
+#
+# Designed to be armed via the Claude Code `Monitor` tool: every stdout line
+# becomes a chat notification. CLAUDE BACKEND ONLY — `Monitor` is a Claude Code
+# harness tool with no Codex (`codex exec`) equivalent.
+#
+# It reads ONLY artifacts the driver already writes:
+#   _v2_checkpoint.json   — completed-phase list
+#   _stdio_*.log          — per-worker stdio (freshness = liveness proxy)
+#   _plamen.log           — driver log tail
+#   ../AUDIT_REPORT.md     — terminal success marker
+#
+# Emits: an immediate report on arm, then one heartbeat every <interval>;
+# plus event-driven PROGRESS / ALERT-STALL lines, and a terminal DONE /
+# ALERT-DEAD when the driver process exits.
+set -u
+
+S="${1:?usage: plamen_monitor.sh <scratchpad_dir> [interval_minutes]}"
+MIN="${2:-15}"
+case "$MIN" in (*[!0-9]*|"") MIN=15 ;; esac
+[ "$MIN" -lt 1 ] 2>/dev/null && MIN=15
+HB=$(( MIN * 60 ))
+R="$(dirname "$S")/AUDIT_REPORT.md"   # AUDIT_REPORT.md sits beside .scratchpad
+
+# Wait up to 3 min for the driver to appear (arming before/with launch is fine).
+g=0
+while [ $g -lt 36 ]; do
+  pgrep -f scripts/plamen_driver >/dev/null 2>&1 && break
+  g=$((g+1)); sleep 5
+done
+echo "$(date +%H:%M:%S) monitor armed @${MIN}m (driver $(pgrep -f scripts/plamen_driver >/dev/null 2>&1 && echo up || echo NOT-up))"
+
+prevphase=""; alerted=0; last_hb=0
+while true; do
+  now=$(date +%s); ts=$(date +%H:%M:%S)
+
+  # Terminal: driver gone.
+  if ! pgrep -f scripts/plamen_driver >/dev/null 2>&1; then
+    if [ -f "$R" ]; then
+      echo "$ts DONE: driver exited, AUDIT_REPORT.md present — audit complete."
+    else
+      echo "$ts ALERT-DEAD: driver gone, no AUDIT_REPORT.md — died/stopped, investigate."
+    fi
+    break
+  fi
+
+  phase=$(python3 -c "import json;print(json.load(open('$S/_v2_checkpoint.json')).get('completed'))" 2>/dev/null || echo '?')
+  newest=$(ls -t "$S"/_stdio_*.log 2>/dev/null | head -1)
+  if [ -n "$newest" ]; then
+    nm=$(stat -c %Y "$newest" 2>/dev/null || echo "$now")
+    nsize=$(wc -c <"$newest" 2>/dev/null || echo 0)
+  else
+    nm=$now; nsize=0
+  fi
+  nm_age=$(( now - nm ))
+  last=$(tail -1 "$S/_plamen.log" 2>/dev/null | sed 's/\x1b\[[0-9;?]*[a-zA-Z]//g' | cut -c1-80)
+
+  # Event: phase progressed.
+  if [ "$phase" != "$prevphase" ] && [ -n "$prevphase" ]; then
+    echo "$ts PROGRESS: completed=$phase"; alerted=0
+  fi
+  prevphase=$phase
+
+  # Event: worker stdio gone quiet (small file >5min, or any file >9min) → likely stuck.
+  if [ $alerted -eq 0 ] && { { [ "$nsize" -lt 2500 ] && [ $nm_age -gt 300 ]; } || [ $nm_age -gt 540 ]; }; then
+    echo "$ts ALERT-STALL: completed=$phase | newest worker stdio idle ${nm_age}s (size ${nsize}B) — likely stuck. last: $last"
+    alerted=1
+  fi
+  [ $nm_age -lt 120 ] && alerted=0   # reset stall latch once activity resumes
+
+  # Heartbeat: immediately on arm, then every <interval>.
+  if [ $(( now - last_hb )) -ge $HB ]; then
+    echo "$ts ok: completed=$phase | worker_idle=${nm_age}s | newest=${nsize}B | last: $last"
+    last_hb=$now
+  fi
+
+  sleep 60
+done


### PR DESCRIPTION
Implements #18. Adds a `plamen monitor <minutes> [path]` command that arms a periodic status heartbeat over an already-running V2 audit, via the Claude Code `Monitor` tool.

- **No driver changes** — reads only artifacts the driver already writes (`_v2_checkpoint.json`, `_stdio_*.log`, `_plamen.log`, `AUDIT_REPORT.md`).
- Emits a report immediately on arm, then every `<minutes>` (default 15), plus event-driven `PROGRESS` / `ALERT-STALL`, and a terminal `DONE` / `ALERT-DEAD` when the driver exits.
- **Claude backend only** — `Monitor` has no Codex (`codex exec`) equivalent; the mode documents this and points Codex users at `tail -f`.
- `scripts/plamen_monitor.sh` is the generalization of a watcher already battle-tested against live Thorough-mode runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
